### PR TITLE
Drop linux-ia32 support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "arduino-cli/darwin-x64/arduino-cli",
     "arduino-cli/linux-arm/arduino-cli",
     "arduino-cli/linux-arm64/arduino-cli",
-    "arduino-cli/linux-ia32/arduino-cli",
     "arduino-cli/linux-x64/arduino-cli",
     "css/main.css",
     "css/extension.css",

--- a/pkg/candle_adapter.py
+++ b/pkg/candle_adapter.py
@@ -112,8 +112,6 @@ class CandleAdapter(Adapter):
                 self.arduino_cli_path = os.path.join(self.add_on_path, 'arduino-cli', 'linux-arm')
             elif machine == 'x86_64':
                 self.arduino_cli_path = os.path.join(self.add_on_path, 'arduino-cli', 'linux-x64')
-            else:
-                self.arduino_cli_path = os.path.join(self.add_on_path, 'arduino-cli', 'linux-ia32')
             #else:
             #    print('Unknown platform!')
             #    self.arduino_cli_path = None


### PR DESCRIPTION
The gateway hasn't been successfully built for 32-bit Linux, so
there's no point in supporting it here.